### PR TITLE
Remove blank key value pairs

### DIFF
--- a/HeldBy_RML/WI_County_Supervisory_Districts_Fall_2023.json
+++ b/HeldBy_RML/WI_County_Supervisory_Districts_Fall_2023.json
@@ -20,7 +20,7 @@
 "dct_issued_s": "",
 "dct_temporal_sm": ["2023"],
 "solr_year_i": 2023,
-"dct_references_s": "{\"\":\"\",\"\":\"\",\"http://schema.org/downloadUrl\":\"https://gisdata.wisc.edu/public/WI_County_Supervisory_Districts_Fall_2023.zip\",\"http://schema.org/url\":\"https://gis-ltsb.hub.arcgis.com/pages/download-data\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://gisdata.wisc.edu/public/metadata/WI_County_Supervisory_Districts_Fall_2023.xml\"}",
+"dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://gisdata.wisc.edu/public/WI_County_Supervisory_Districts_Fall_2023.zip\",\"http://schema.org/url\":\"https://gis-ltsb.hub.arcgis.com/pages/download-data\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://gisdata.wisc.edu/public/metadata/WI_County_Supervisory_Districts_Fall_2023.xml\"}",
 "solr_geom": "ENVELOPE(-92.889345, -86.763994, 47.08078, 42.491913)",
 "uw_supplemental_s": "This is an archived copy of the data held at UW-Madison.For access to the most current data for this county, please visit: https://gis-ltsb.hub.arcgis.com/pages/download-data",
 "uw_notice_s": ""

--- a/HeldBy_RML/WI_County_Supervisory_Districts_Spring_2022.json
+++ b/HeldBy_RML/WI_County_Supervisory_Districts_Spring_2022.json
@@ -20,7 +20,7 @@
 "dct_issued_s": "",
 "dct_temporal_sm": ["2022"],
 "solr_year_i": 2022,
-"dct_references_s": "{\"\":\"\",\"\":\"\",\"http://schema.org/downloadUrl\":\"https://gisdata.wisc.edu/public/WI_County_Supervisory_Districts_Spring_2022.zip\",\"http://schema.org/url\":\"https://gis-ltsb.hub.arcgis.com/\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://gisdata.wisc.edu/public/metadata/WI_County_Supervisory_Districts_Spring_2022.xml\"}",
+"dct_references_s": "{\"http://schema.org/downloadUrl\":\"https://gisdata.wisc.edu/public/WI_County_Supervisory_Districts_Spring_2022.zip\",\"http://schema.org/url\":\"https://gis-ltsb.hub.arcgis.com/\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"https://gisdata.wisc.edu/public/metadata/WI_County_Supervisory_Districts_Spring_2022.xml\"}",
 "solr_geom": "ENVELOPE(-92.964428, -86.6661, 47.083094, 42.456895)",
 "uw_supplemental_s": "This is an archived copy of the data held at UW-Madison. For access to the most current data please visit: [https://gis-ltsb.hub.arcgis.com/]",
 "uw_notice_s": ""


### PR DESCRIPTION
Two files had some blank key:value pairs in the dct_references_s field, which errored out when I tried to process them. I just removed those characters and was able to run the GBL to Aardvark script. 